### PR TITLE
feat : 채팅 입력 시 DB저장기능 추가 (추후 채팅방 조회 시 채팅내역 뜨게 처리할 예정)

### DIFF
--- a/src/main/java/com/example/placemeeting/controller/ChatRoomController.java
+++ b/src/main/java/com/example/placemeeting/controller/ChatRoomController.java
@@ -2,26 +2,22 @@ package com.example.placemeeting.controller;
 
 
 import com.example.placemeeting.domain.ChatRoom;
-import com.example.placemeeting.dto.reqeustdto.ChatRoomRequest;
 import com.example.placemeeting.dto.reqeustdto.ChatRoomRequest.ChatRoomCreate;
-import com.example.placemeeting.dto.responsedto.ChatRoomResponse;
 import com.example.placemeeting.dto.responsedto.ChatRoomResponse.ChatRoomResDto;
 import com.example.placemeeting.global.dto.ResponseDto;
 import com.example.placemeeting.security.user.UserDetailsImpl;
-import com.example.placemeeting.service.ChatService;
+import com.example.placemeeting.service.ChatRoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
-import java.net.http.HttpResponse;
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/chat")
 public class ChatRoomController {
-    private final ChatService chatService;
+    private final ChatRoomService chatService;
 
     // 모든 채팅방 목록 반환
     @GetMapping("/rooms")

--- a/src/main/java/com/example/placemeeting/domain/ChatMessage.java
+++ b/src/main/java/com/example/placemeeting/domain/ChatMessage.java
@@ -1,5 +1,6 @@
 package com.example.placemeeting.domain;
 
+import com.example.placemeeting.dto.reqeustdto.ChatMessageRequest;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -33,4 +34,12 @@ public class ChatMessage extends BaseEntity { //뷰로 보내는 메세지
     private String message;
 
     private String sendTime;
+
+    public ChatMessage(ChatMessageRequest.ChatMessageCreate chatMessageCreate) {
+        this.type = chatMessageCreate.getType();
+        this.roomId = chatMessageCreate.getRoomId();
+        this.sender = chatMessageCreate.getSender();
+        this.message = chatMessageCreate.getMessage();
+        this.sendTime = chatMessageCreate.getSendTime();
+    }
 }

--- a/src/main/java/com/example/placemeeting/dto/reqeustdto/ChatMessageRequest.java
+++ b/src/main/java/com/example/placemeeting/dto/reqeustdto/ChatMessageRequest.java
@@ -1,0 +1,39 @@
+package com.example.placemeeting.dto.reqeustdto;
+
+
+import com.example.placemeeting.domain.ChatMessage;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ChatMessageRequest {
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class ChatMessageCreate {
+
+        public enum MessageType {
+            ENTER, TALK, QUIT
+        }
+
+        private ChatMessage.MessageType type;
+        //채팅방 ID
+        private String roomId;
+        //보내는 사람
+        private String sender;
+        //내용
+        private String message;
+
+        private String sendTime;
+
+        public ChatMessageCreate(ChatMessage chatMessage) {
+            this.type = chatMessage.getType();
+            this.roomId = chatMessage.getRoomId();
+            this.sender = chatMessage.getSender();
+            this.message = chatMessage.getMessage();
+            this.sendTime = chatMessage.getSendTime();
+        }
+
+    }
+}

--- a/src/main/java/com/example/placemeeting/service/ChatMessageService.java
+++ b/src/main/java/com/example/placemeeting/service/ChatMessageService.java
@@ -1,0 +1,39 @@
+package com.example.placemeeting.service;
+
+import com.example.placemeeting.domain.ChatMessage;
+import com.example.placemeeting.domain.ChatRoom;
+import com.example.placemeeting.domain.Member;
+import com.example.placemeeting.dto.reqeustdto.ChatMessageRequest;
+import com.example.placemeeting.dto.reqeustdto.ChatRoomRequest;
+import com.example.placemeeting.repository.ChatMessageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ChatMessageService {
+
+    private final ChatMessageRepository chatMessageRepository;
+
+    @Transactional
+    public ChatMessageRequest.ChatMessageCreate createChatMessage(ChatMessageRequest.ChatMessageCreate chatMessageCreate) {
+        ChatMessage chatMessage = new ChatMessage(chatMessageCreate);
+        chatMessageRepository.save(chatMessage);
+        return chatMessageCreate;
+    }
+}
+
+    //채팅메시지 생성
+//    public ChatMessageRequest.ChatMessageCreate createChatMessage() {
+
+
+
+//    public ChatRoom createRoom(ChatRoomRequest.ChatRoomCreate chatRoomCreate, Member member) {
+//        ChatRoom chatRoom = new ChatRoom(chatRoomCreate.getChatType(), member);
+//        chatRoomRepository.save(chatRoom);
+//        return chatRoom;
+
+

--- a/src/main/java/com/example/placemeeting/service/ChatRoomService.java
+++ b/src/main/java/com/example/placemeeting/service/ChatRoomService.java
@@ -3,7 +3,6 @@ package com.example.placemeeting.service;
 import com.example.placemeeting.domain.ChatRoom;
 import com.example.placemeeting.domain.Member;
 import com.example.placemeeting.dto.reqeustdto.ChatRoomRequest.ChatRoomCreate;
-import com.example.placemeeting.dto.responsedto.ChatRoomResponse;
 import com.example.placemeeting.dto.responsedto.ChatRoomResponse.ChatRoomResDto;
 import com.example.placemeeting.exception.CustomCommonException;
 import com.example.placemeeting.exception.ErrorCode;
@@ -14,7 +13,6 @@ import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -22,7 +20,7 @@ import java.util.stream.Collectors;
 @Service
 @Slf4j
 @RequiredArgsConstructor
-public class ChatService {
+public class ChatRoomService {
 
     private Map<String, ChatRoom> chatRooms;
 


### PR DESCRIPTION
의문사항 : 채팅내역이 뜨는 건 빠르게 처리할 수록 좋은 것이니, disk기반인 db말고 inmemory방식인 redis 안에 삽입 및 출력 시키는 게 더 낫지않을까? 라는 생각이 듦. 우선 db에 저장하는 형태는 갖추어뒀으니 계속 개선시키는 방향을 알아봐야할 것 같음 (redis 공부해보자)